### PR TITLE
Add copyleft notice to the footer

### DIFF
--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -23,7 +23,7 @@
     <Logo type="mono" color="#2e2e2e" size="100px" />
   </div>
   <div id="info">
-    <div class="child"><span>🄯 2022 Novao Technologies</span></div>
+    <div class="child"><span>🄯 (Copyleft) 2022 Novao Technologies</span></div>
     <div class="child"><span>All wrongs reserved</span></div>
     <div class="child">
       <a href="https://github.com/novaotech/website/">Code available here</a>


### PR DESCRIPTION
This is a temporary fix for platforms which can't display the "Copyleft" symbol. At a later point, I'll implement a fill-in image instead of using the sparsely supported unicode character.